### PR TITLE
Remove argparse and ecdsa

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-argparse==1.2.1
-ecdsa==0.13
 lockfile==0.9.1
 psutil==4.0.0


### PR DESCRIPTION
Neither of these dependencies are distributed anymore with Pivotal Greenplum 6, therefore we should not include them in Legal Review and OSL attribution, which is what this file controls.